### PR TITLE
Implement Docker build and docker-compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,16 @@
 	"name": "Config Service b1",
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/go:1": {
 			"golangciLintVersion": "latest",
 			"version": "1.25.0"
 		}
 	},
-	"updateContentCommand": "bash .devcontainer/scripts/update-content.sh"
+	"updateContentCommand": "bash .devcontainer/scripts/update-content.sh",
+	"forwardPorts": [
+		8000,
+		8500,
+		8600
+	]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1 (Build)
+FROM golang:1.25.0-alpine AS builder
+
+WORKDIR /app/
+COPY go.mod go.sum /app/
+RUN go mod download
+COPY . /app/
+
+RUN CGO_ENABLED=0 go build \
+	-ldflags="-s -w" \
+	-v \
+	-trimpath \
+	-o config-service \
+	main.go
+
+RUN echo "ID=\"distroless\"" > /etc/os-release
+
+# Stage 2 (Final)
+FROM gcr.io/distroless/static:latest
+COPY --from=builder /etc/os-release /etc/os-release
+
+COPY --from=builder /app/config-service /usr/bin/
+
+ENTRYPOINT ["/usr/bin/config-service"]
+
+EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  server:
+    build: .
+    restart: always
+    ports:
+      - 8000:8000
+    environment:
+      - PORT=8000
+      - CONSUL_ADDRESS=consul:8500
+    depends_on:
+      consul:
+        condition: service_healthy
+
+  consul:
+    image: hashicorp/consul:1.21
+    ports:
+      - 8500:8500
+      - 8600:8600/tcp
+      - 8600:8600/udp
+    command: "agent -server -ui -node=server-1 -bootstrap-expect=1 -client=0.0.0.0"
+    volumes:
+      - consul_store:/consul/data
+    healthcheck:
+      test: ["CMD", "consul", "info"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  consul_store:

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -24,11 +25,16 @@ func main() {
 	router := mux.NewRouter()
 
 	consulConfig := api.DefaultConfig()
-	consulConfig.Address = "127.0.0.1:8500" // Or from config
+	consulConfig.Address = os.Getenv("CONSUL_ADDRESS")
 	consulClient, _ := api.NewClient(consulConfig)
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+
 	srv := http.Server{
-		Addr:    ":8000",
+		Addr:    ":" + port,
 		Handler: routers.HandleRequests(router, limiter, consulClient),
 	}
 
@@ -36,7 +42,7 @@ func main() {
 	// this block will never be executed since the go-routine will be used by the server which will
 	// listen for requests throughout its lifecycle
 	go func() {
-		fmt.Println("Listening on port :8000")
+		fmt.Println("Listening on port :" + port)
 		if err := srv.ListenAndServe(); err != nil {
 			log.Fatal("Stopped listening: " + err.Error())
 		}


### PR DESCRIPTION
Implements containerization and Docker compose services.

`Dockerfile`:
- Multi-stage build using `golang:1.25.0-alpine` with final layer from `distroless` to create a small, secure, static binary image

`docker-compose.yml`:
- Created a local service of the above Dockerfile under name `server`
- Added Consul `hashicorp/consul:1.21` as the second service with UI, persistent volume and healthcheck

The app now utilizes `PORT` environment variable as the port to listen to, defaulting to `8000` if not set. 
It requires to set the `CONSUL_ADDRESS` to correct address in the `ip:port` format to connect to the running Consul application.

Adjusts Devcontainer to use Docker-in-Docker feature to support testing with Docker and forwards  ports `8000`, `8500`, and `8600` automatically.